### PR TITLE
feat!: Rename `Color.toHexString` to `Color.toCssHex`

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,12 @@ All notable changes to this project will be documented in this file.
 The format is based on https://keepachangelog.com/[Keep a Changelog], and this
 project adheres to https://semver.org/[Semantic Versioning].
 
+== {compare-url}/v0.2.0\...HEAD[Unreleased]
+
+=== Changed
+
+* Rename `Color.toHexString` to `Color.toCssHex` ({pull-request-url}/18[#18])
+
 == {compare-url}/v0.1.0\...v0.2.0[0.2.0] - 2025-08-22
 
 === Changed

--- a/examples/parse.zig
+++ b/examples/parse.zig
@@ -30,7 +30,7 @@ pub fn main() !void {
         try stdout.print("Name: {s}\n", .{name});
     {
         var buf: [9]u8 = undefined;
-        const hex = try color.toHexString(&buf);
+        const hex = try color.toCssHex(&buf);
         try stdout.print("Hex: {s}\n", .{hex});
     }
     {

--- a/src/color.zig
+++ b/src/color.zig
@@ -109,7 +109,7 @@ pub fn Color(comptime T: type) type {
             const color = Color(f64).fromRgba8(165, 42, 42, 255);
             try testing.expectEqualStrings("brown", color.name().?);
             var buf: [7]u8 = undefined;
-            const hex = try color.toHexString(&buf);
+            const hex = try color.toCssHex(&buf);
             try testing.expectEqualStrings("#a52a2a", hex);
         }
 
@@ -152,7 +152,7 @@ pub fn Color(comptime T: type) type {
             const color = Color(f64).fromHsl(248.0, 0.39, 0.392, 1.0);
             try testing.expectEqual(null, color.name());
             var buf: [7]u8 = undefined;
-            const hex = try color.toHexString(&buf);
+            const hex = try color.toCssHex(&buf);
             try testing.expectEqualStrings("#473d8b", hex);
         }
 
@@ -186,7 +186,7 @@ pub fn Color(comptime T: type) type {
             const color = Color(f64).fromHwb(50.6, 0.0, 0.0, 1.0);
             try testing.expectEqualStrings("gold", color.name().?);
             var buf: [7]u8 = undefined;
-            const hex = try color.toHexString(&buf);
+            const hex = try color.toCssHex(&buf);
             try testing.expectEqualStrings("#ffd700", hex);
         }
 
@@ -554,7 +554,7 @@ pub fn Color(comptime T: type) type {
                     .{ color.red, color.green, color.blue, color.alpha },
                 );
                 try testing.expectEqual(.{ 255, 255, 0, 255 }, color.toRgba8());
-                const hex = try color.toHexString(&buf);
+                const hex = try color.toCssHex(&buf);
                 try testing.expectEqualStrings("#ffff00", hex);
             }
 
@@ -565,7 +565,7 @@ pub fn Color(comptime T: type) type {
                     .{ color.red, color.green, color.blue, color.alpha },
                 );
                 try testing.expectEqual(.{ 255, 0, 0, 255 }, color.toRgba8());
-                const hex = try color.toHexString(&buf);
+                const hex = try color.toCssHex(&buf);
                 try testing.expectEqualStrings("#ff0000", hex);
             }
 
@@ -576,14 +576,14 @@ pub fn Color(comptime T: type) type {
                     .{ color.red, color.green, color.blue, color.alpha },
                 );
                 try testing.expectEqual(.{ 255, 0, 0, 255 }, color.toRgba8());
-                const hex = try color.toHexString(&buf);
+                const hex = try color.toCssHex(&buf);
                 try testing.expectEqualStrings("#ff0000", hex);
             }
 
             {
                 const color = try Color(f64).parse("#ff00007f");
                 try testing.expectEqual(.{ 255, 0, 0, 127 }, color.toRgba8());
-                const hex = try color.toHexString(&buf);
+                const hex = try color.toCssHex(&buf);
                 try testing.expectEqualStrings("#ff00007f", hex);
             }
         }
@@ -702,9 +702,9 @@ pub fn Color(comptime T: type) type {
         }
 
         /// Returns the
-        /// [RGB hexadecimal color string](https://www.w3.org/TR/css-color-4/#hex-notation)
+        /// [CSS RGB hexadecimal color representation](https://www.w3.org/TR/css-color-4/#hex-notation)
         /// of this `Color` in lower case.
-        pub fn toHexString(self: Self, buf: []u8) BufPrintError![]u8 {
+        pub fn toCssHex(self: Self, buf: []u8) BufPrintError![]u8 {
             const r, const g, const b, const a = self.toRgba8();
 
             return if (a < math.maxInt(u8))
@@ -713,15 +713,15 @@ pub fn Color(comptime T: type) type {
                 fmt.bufPrint(buf, "#{x:0>2}{x:0>2}{x:0>2}", .{ r, g, b });
         }
 
-        test toHexString {
+        test toCssHex {
             var buf: [9]u8 = undefined;
 
             const color = try Color(f64).parse("mediumpurple");
-            const hex = try color.toHexString(&buf);
+            const hex = try color.toCssHex(&buf);
             try testing.expectEqualStrings("#9370db", hex);
 
             const color_with_alpha = try Color(f64).parse("rgb(147 112 219 / 49.8%)");
-            const hex_with_alpha = try color_with_alpha.toHexString(&buf);
+            const hex_with_alpha = try color_with_alpha.toCssHex(&buf);
             try testing.expectEqualStrings("#9370db7f", hex_with_alpha);
         }
 

--- a/tests/color.zig
+++ b/tests/color.zig
@@ -18,7 +18,7 @@ test "basic" {
                 .{ color.red, color.green, color.blue, color.alpha },
             );
             try testing.expectEqual(.{ 255, 0, 0, 255 }, color.toRgba8());
-            const hex = try color.toHexString(&buf);
+            const hex = try color.toCssHex(&buf);
             try testing.expectEqualStrings("#ff0000", hex);
             try testing.expectEqual(.{ 0.0, 1.0, 0.5, 1.0 }, color.toHsl());
             try testing.expectEqual(.{ 0.0, 0.0, 0.0, 1.0 }, color.toHwb());
@@ -28,7 +28,7 @@ test "basic" {
         {
             const color = Color(ft).init(1.0, 0.0, 0.0, 0.5);
             try testing.expectEqual(.{ 255, 0, 0, 128 }, color.toRgba8());
-            const hex = try color.toHexString(&buf);
+            const hex = try color.toCssHex(&buf);
             try testing.expectEqualStrings("#ff000080", hex);
         }
 
@@ -99,16 +99,16 @@ test "convert colors" {
                 {
                     const a, const b, const c, const d = col.toLinearRgb();
                     const x = Color(ft).fromLinearRgb(a, b, c, d);
-                    const col_hex = try col.toHexString(&buf);
-                    const x_hex = try x.toHexString(&buf);
+                    const col_hex = try col.toCssHex(&buf);
+                    const x_hex = try x.toCssHex(&buf);
                     try testing.expectEqualStrings(col_hex, x_hex);
                 }
 
                 {
                     const a, const b, const c, const d = col.toOklab();
                     const x = Color(ft).fromOklab(a, b, c, d);
-                    const col_hex = try col.toHexString(&buf);
-                    const x_hex = try x.toHexString(&buf);
+                    const col_hex = try col.toCssHex(&buf);
+                    const x_hex = try x.toCssHex(&buf);
                     try testing.expectEqualStrings(col_hex, x_hex);
                 }
             }
@@ -139,41 +139,41 @@ test "convert colors" {
         inline for (float_types) |ft| {
             for (data) |s| {
                 const col = try Color(ft).parse(s);
-                const hex = try col.toHexString(&buf);
+                const hex = try col.toCssHex(&buf);
                 try testing.expectEqualStrings(s, hex);
 
                 {
                     const a, const b, const c, const d = col.toRgba8();
                     const x = Color(ft).fromRgba8(a, b, c, d);
-                    const x_hex = try x.toHexString(&buf);
+                    const x_hex = try x.toCssHex(&buf);
                     try testing.expectEqualStrings(s, x_hex);
                 }
 
                 {
                     const a, const b, const c, const d = col.toHsl();
                     const x = Color(ft).fromHsl(a, b, c, d);
-                    const x_hex = try x.toHexString(&buf);
+                    const x_hex = try x.toCssHex(&buf);
                     try testing.expectEqualStrings(s, x_hex);
                 }
 
                 {
                     const a, const b, const c, const d = col.toHwb();
                     const x = Color(ft).fromHwb(a, b, c, d);
-                    const x_hex = try x.toHexString(&buf);
+                    const x_hex = try x.toCssHex(&buf);
                     try testing.expectEqualStrings(s, x_hex);
                 }
 
                 {
                     const a, const b, const c, const d = col.toLinearRgb();
                     const x = Color(ft).fromLinearRgb(a, b, c, d);
-                    const x_hex = try x.toHexString(&buf);
+                    const x_hex = try x.toCssHex(&buf);
                     try testing.expectEqualStrings(s, x_hex);
                 }
 
                 {
                     const a, const b, const c, const d = col.toOklab();
                     const x = Color(ft).fromOklab(a, b, c, d);
-                    const x_hex = try x.toHexString(&buf);
+                    const x_hex = try x.toCssHex(&buf);
                     try testing.expectEqualStrings(s, x_hex);
                 }
             }

--- a/tests/named_colors.zig
+++ b/tests/named_colors.zig
@@ -197,7 +197,7 @@ test "named_colors" {
         inline for (float_types) |ft| {
             outer: for (test_data) |td| {
                 const c1 = try Color(ft).parse(td[0]);
-                const hex = try c1.toHexString(&buf);
+                const hex = try c1.toCssHex(&buf);
                 try testing.expectEqualStrings(td[1], hex);
 
                 for (skip_list) |nc|


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/csscolorparser-zig/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/csscolorparser-zig/blob/develop/CODE_OF_CONDUCT.md
